### PR TITLE
added support for declaring imported schema files to load before other files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Credits
 - [Daniel Lundin](https://github.com/dln)
 - [Vince Tse](https://github.com/vtonehundred)
 - [Jerome Wacongne](https://github.com/ch4mpy)
+- [Ryan Koval](http://github.ryankoval.com)
 
 #### Fork away, just make sure the tests pass before you send a pull request.
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,23 @@ Settings
 | ------------- |:-------------:| -----:| -----:|
 | sourceDirectory     | ``source-directory`` | ``src/main/avro`` | Path containing ``*.avsc``, ``*.avdl``, and/or ``*.avro`` files. |
 | scalaSource      | ``scala-source``      |   ``$sourceManaged/main`` |   Path for the generated ``*.scala`` or ``*.java``  files. |
+|sbt.SbtAvrohugger.imports|`'imports'`|`Seq.empty`|A `Seq[File]` of Avro schemas to load before all other schema files. Sometimes necessary if you are referencing types defined in other schema files.
 
 
 Changing Settings
 -----------------
 
-Settings can be overridden by adding a line to ``myproject/build.sbt``:
+Settings can be overridden by adding lines to ``myproject/build.sbt``:
 
-    (scalaSource in avroConfig) := new java.io.File("myscalaSource")
-
+```scala
+import sbt.SbtAvroHugger.imports
+    
+(scalaSource in avroConfig) := new java.io.File("myscalaSource")
+    
+(imports in avroConfig) ++= {
+  Seq((sourceDirectory in avroConfig).value / "Import.avsc")
+}
+```
 
 
 Tasks

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object build extends Build {
     base = file("."),
     settings = Defaults.defaultSettings ++ scriptedSettings ++ Seq[Project.Setting[_]](
       organization := "com.julianpeeters",
-      version := "0.4.1",
+      version := "0.4.2",
       sbtPlugin := true,
       scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard"),
       resolvers += Resolver.file("Local Ivy Repository", file("/home/julianpeeters/.ivy2/local/"))(Resolver.ivyStylePatterns),

--- a/src/main/scala/sbtavrohugger/FileWriter.scala
+++ b/src/main/scala/sbtavrohugger/FileWriter.scala
@@ -3,32 +3,50 @@ package sbtavrohugger;
 import avrohugger.Generator
 import java.io.File
 import sbt.Keys._
-import sbt.{ Logger, globFilter, singleFileFinder }
+import sbt.{Logger, globFilter, singleFileFinder}
+import sbt.Path._
 
 object FileWriter {
 
   private[sbtavrohugger] def generateCaseClasses(
     generator: Generator,
+    imports: Seq[File],
     srcDir: File,
     target: File,
     log: Logger): Set[java.io.File] = {
 
-    for (idl <- (srcDir ** "*.avdl").get) {
+    val importsGroupedByExtension = imports.groupBy(_.ext)
+
+    def getSchemasFor(extension: String): Seq[File] = {
+      val importsForExtension = importsGroupedByExtension.getOrElse(extension, Seq.empty)
+      val sortedSchemas = {
+        val allSchemas = (srcDir ** s"*.$extension").get
+        if (extension == "avsc") {
+          AVSCFileSorter.sortSchemaFiles(allSchemas)
+        } else {
+          allSchemas
+        }
+
+      }
+      importsForExtension ++ (sortedSchemas --- importsForExtension).get
+    }
+
+    for (idl <- getSchemasFor(extension = "avdl")) {
       log.info("Compiling Avro IDL %s".format(idl))
       generator.fileToFile(idl, target.getPath)
     }
 
-    for (inFile <- AVSCFileSorter.sortSchemaFiles((srcDir ** "*.avsc").get)) {
+    for (inFile <- getSchemasFor(extension = "avsc")) {
       log.info("Compiling AVSC %s".format(inFile))
       generator.fileToFile(inFile, target.getPath)
     }
 
-    for (inFile <- (srcDir ** "*.avro").get) {
+    for (inFile <- getSchemasFor(extension = "avro")) {
       log.info("Compiling Avro datafile %s".format(inFile))
       generator.fileToFile(inFile, target.getPath)
     }
 
-    for (protocol <- (srcDir ** "*.avpr").get) {
+    for (protocol <- getSchemasFor(extension = "avpr")) {
       log.info("Compiling Avro protocol %s".format(protocol))
       generator.fileToFile(protocol, target.getPath)
     }

--- a/src/main/scala/sbtavrohugger/SbtAvrohugger.scala
+++ b/src/main/scala/sbtavrohugger/SbtAvrohugger.scala
@@ -1,18 +1,13 @@
 package sbtavrohugger
+
+import sbt.KeyRanks._
 import settings.{ AvroSettings, SpecificAvroSettings }
 
 import java.io.File
 import scala.collection.JavaConverters._
 
 import sbt.Keys._
-import sbt.{
-  Classpaths,
-  Compile,
-  Plugin,
-  Setting,
-  config,
-  richFile
-}
+import sbt._
 
 /**
  * Simple plugin for generating the Scala sources for Avro IDL, schemas and protocols.
@@ -21,6 +16,11 @@ object SbtAvrohugger extends Plugin {
 
   val avroConfig = config("avro")
 
+  val imports = SettingKey[Seq[File]]("imports", "Ordered list of files for Avro to import before applying recursive " +
+    "generation. Sometimes necessary for multiple Avro schema files that reference types defined within each " +
+    "other", AMinusSetting)
+
+  val importFiles = imports := Seq.empty[File]
   val inputDir = sourceDirectory <<= (sourceDirectory in Compile) { _ / "avro" }
   val outputDir = scalaSource <<= (sourceManaged in Compile) { _ / "" }
 
@@ -29,11 +29,11 @@ object SbtAvrohugger extends Plugin {
   }
 
   lazy val avroSettings: Seq[Setting[_]] = {
-    AvroSettings.getSettings(avroConfig, inputDir, outputDir, classPath)
+    AvroSettings.getSettings(avroConfig, importFiles, inputDir, outputDir, classPath)
   }
 
   lazy val specificAvroSettings: Seq[Setting[_]] = {
-    SpecificAvroSettings.getSettings(avroConfig, inputDir, outputDir, classPath)
+    SpecificAvroSettings.getSettings(avroConfig, importFiles, inputDir, outputDir, classPath)
   }
 
 }

--- a/src/main/scala/sbtavrohugger/settings/AvroSettings.scala
+++ b/src/main/scala/sbtavrohugger/settings/AvroSettings.scala
@@ -22,11 +22,13 @@ object AvroSettings  {
 
   def getSettings(
     avroConfig: Configuration,
+    imports: Setting[Seq[File]],
     inputDir: Setting[File],
     outputDir: Setting[File],
     classPath: Setting[Task[Classpath]]): Seq[Setting[_]] = {
 
     inConfig(avroConfig)(Seq[Setting[_]](
+    imports,
     inputDir,
     outputDir,
     classPath,

--- a/src/main/scala/sbtavrohugger/settings/SpecificAvroSettings.scala
+++ b/src/main/scala/sbtavrohugger/settings/SpecificAvroSettings.scala
@@ -21,11 +21,13 @@ object SpecificAvroSettings {
 
   def getSettings(
     avroConfig: Configuration,
+    imports: Setting[Seq[File]],
     inputDir: Setting[File],
     outputDir: Setting[File],
     classPath: Setting[Task[Classpath]]): Seq[Setting[_]] = {
 
     inConfig(avroConfig)(Seq[Setting[_]](
+      imports,
       inputDir,
       outputDir,
       classPath,

--- a/src/main/scala/sbtavrohugger/tasks/GeneratorTask.scala
+++ b/src/main/scala/sbtavrohugger/tasks/GeneratorTask.scala
@@ -3,6 +3,7 @@ package tasks
 
 import avrohugger.Generator
 import avrohugger.format.{ Standard, SpecificRecord }
+import sbtavrohugger.SbtAvrohugger.imports
 
 import java.io.File
 
@@ -20,15 +21,16 @@ object GeneratorTask {
 
   private[sbtavrohugger] def caseClassGeneratorTask(avroConfig: Config) = {
     (streams,
+    imports in avroConfig,
     sourceDirectory in avroConfig,
     scalaSource in avroConfig,
     target) map {
-      (o, srcDir, targetDir, cache) =>
+      (o, imports, srcDir, targetDir, cache) =>
         val cachedCompile = FileFunction.cached(cache / "avro",
           inStyle = FilesInfo.lastModified,
           outStyle = FilesInfo.exists) { (in: Set[File]) =>
             val generator = new Generator(Standard)
-            FileWriter.generateCaseClasses(generator, srcDir, targetDir, o.log)
+            FileWriter.generateCaseClasses(generator, imports, srcDir, targetDir, o.log)
           }
         cachedCompile((srcDir ** "*.av*").get.toSet).toSeq
     }

--- a/src/main/scala/sbtavrohugger/tasks/SpecificGeneratorTask.scala
+++ b/src/main/scala/sbtavrohugger/tasks/SpecificGeneratorTask.scala
@@ -3,6 +3,7 @@ package tasks
 
 import avrohugger.Generator
 import avrohugger.format.{ Standard, SpecificRecord }
+import sbtavrohugger.SbtAvrohugger.imports
 
 import java.io.File
 
@@ -20,15 +21,16 @@ object SpecificGeneratorTask {
 
   private[sbtavrohugger] def specificCaseClassGeneratorTask(
     avroConfig: sbt.Configuration) = (streams,
+    imports in avroConfig,
     sourceDirectory in avroConfig,
     scalaSource in avroConfig,
     target) map {
-      (o, srcDir, targetDir, cache) =>
+      (o, imports, srcDir, targetDir, cache) =>
         val cachedCompile = FileFunction.cached(cache / "avro",
           inStyle = FilesInfo.lastModified,
           outStyle = FilesInfo.exists) { (in: Set[File]) =>
             val generator = new Generator(SpecificRecord)
-            FileWriter.generateCaseClasses(generator, srcDir, targetDir, o.log)
+            FileWriter.generateCaseClasses(generator, imports, srcDir, targetDir, o.log)
           }
         cachedCompile((srcDir ** "*.av*").get.toSet).toSeq
     }

--- a/src/sbt-test/projects/GenerateWithImports/build.sbt
+++ b/src/sbt-test/projects/GenerateWithImports/build.sbt
@@ -1,0 +1,15 @@
+import sbtavrohugger.SbtAvrohugger.imports
+
+sbtavrohugger.SbtAvrohugger.specificAvroSettings
+
+organization := "com.julianpeeters"
+
+name := "generate-with-imports"
+
+version := "0.1"
+
+(imports in avroConfig) ++= {
+  Seq(
+    (sourceDirectory in avroConfig).value / "b.avsc"
+  )
+}

--- a/src/sbt-test/projects/GenerateWithImports/project/plugins.sbt
+++ b/src/sbt-test/projects/GenerateWithImports/project/plugins.sbt
@@ -1,0 +1,5 @@
+addSbtPlugin("com.julianpeeters" % "sbt-avrohugger" % "latest.integration")
+
+resolvers += Resolver.file("Local Ivy Repository", file("~/.ivy2/local/"))(Resolver.ivyStylePatterns)
+
+

--- a/src/sbt-test/projects/GenerateWithImports/src/main/avro/a.avsc
+++ b/src/sbt-test/projects/GenerateWithImports/src/main/avro/a.avsc
@@ -1,0 +1,11 @@
+{
+ "namespace": "example",
+ "type": "record",
+ "name": "A",
+ "fields": [
+  {
+   "name": "user",
+   "type": "User"
+  }
+ ]
+}

--- a/src/sbt-test/projects/GenerateWithImports/src/main/avro/b.avsc
+++ b/src/sbt-test/projects/GenerateWithImports/src/main/avro/b.avsc
@@ -1,0 +1,10 @@
+{
+ "namespace": "example",
+ "type": "record",
+ "name": "User",
+ "fields": [
+     {"name": "name", "type": "string"},
+     {"name": "favorite_number",  "type": ["int", "null"]},
+     {"name": "favorite_color", "type": ["string", "null"]}
+ ]
+}

--- a/src/sbt-test/projects/GenerateWithImports/src/main/avro/c.avsc
+++ b/src/sbt-test/projects/GenerateWithImports/src/main/avro/c.avsc
@@ -1,0 +1,11 @@
+{
+ "namespace": "example",
+ "type": "record",
+ "name": "C",
+ "fields": [
+  {
+   "name": "user",
+   "type": "User"
+  }
+ ]
+}

--- a/src/sbt-test/projects/GenerateWithImports/test
+++ b/src/sbt-test/projects/GenerateWithImports/test
@@ -1,0 +1,9 @@
+> update
+
+> avro:generate-specific
+
+$ exists target/scala-2.10/src_managed/main/example/A.scala
+
+$ exists target/scala-2.10/src_managed/main/example/B.scala
+
+$ exists target/scala-2.10/src_managed/main/example/User.scala


### PR DESCRIPTION
## Background

I'm working with an organization that generates POJOs for both Java and Scala applications. We have a handful of schema files defined, but some of them declare types to be used in other schema files. As such, these files need to be loaded first.

## Motivation
On the Java side, we're using the Maven plugin to generate the files. This plugin has support for defining these sorts of imports, so we use that to circumvent this problem. I can't seem to find documentation on their main site for it, but [this JIRA issue comment](https://issues.apache.org/jira/browse/AVRO-1188?focusedCommentId=13495383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13495383) illustrates the usage on that end for that plugin.

This PR aims to replicate the above functionality in SBT, since it didn't seem like such functionality existed prior (though, see [my PR comment below](https://github.com/julianpeeters/sbt-avrohugger/pull/7#discussion_r42072687) for something potentially related)

## Feedback
Please let me know if you have any feedback on this to get it moving. I'd like to get this merged in and published out so that we can pull a more proper release from the project that has this functionality! Thanks!