### PR TITLE
strAsJson will sometimes have no fields

### DIFF
--- a/src/main/scala/sbtavrohugger/AVSCFileSorter.scala
+++ b/src/main/scala/sbtavrohugger/AVSCFileSorter.scala
@@ -64,7 +64,7 @@ object AVSCFileSorter {
   }
 
   def findReferredTypes(strAsJson: JsValue): List[String] = {
-    val fields = strAsJson.asJsObject.fields(Keys.Fields).asInstanceOf[JsArray]
+    val fields = strAsJson.asJsObject.fields.getOrElse(Keys.Fields, JsArray.empty).asInstanceOf[JsArray]
     val referredTypes = for {
       element <- fields.elements
       (key, typeValue) <- element.asJsObject.fields


### PR DESCRIPTION
strAsJson will sometimes have no fields. This causes the plugin to crash. This is just one way to fix it. I'm mostly passing this along so the issue is known. I wish I could provide a test, but minimizing the issue would take me too long, and the code is proprietary.