### PR TITLE
Use includeFilter and excludeFilter to specify what Avro files to use

### DIFF
--- a/src/main/scala/sbtavrohugger/FileWriter.scala
+++ b/src/main/scala/sbtavrohugger/FileWriter.scala
@@ -1,11 +1,10 @@
-package sbtavrohugger;
+package sbtavrohugger
 
-import filesorter.AVSCFileSorter
-import avrohugger.Generator
 import java.io.File
-import sbt.Keys._
-import sbt.{Logger, globFilter, singleFileFinder}
-import sbt.Path._
+
+import avrohugger.Generator
+import sbt.{FileFilter, Logger, globFilter, singleFileFinder}
+import sbtavrohugger.filesorter.AVSCFileSorter
 
 object FileWriter {
 
@@ -13,25 +12,26 @@ object FileWriter {
     generator: Generator,
     srcDir: File,
     target: File,
-    log: Logger): Set[java.io.File] = {
+    log: Logger,
+    inFilter: FileFilter,
+    exFilter: FileFilter): Set[java.io.File] = {
 
-    for (inFile <- AVSCFileSorter.sortSchemaFiles((srcDir ** "*.avsc").get)) {
+    for (inFile <- AVSCFileSorter.sortSchemaFiles((srcDir ** "*.avsc").get) if inFilter.accept(inFile) && !exFilter.accept(inFile)) {
       log.info("Compiling AVSC %s".format(inFile))
       generator.fileToFile(inFile, target.getPath)
     }
 
-    for (idl <- (srcDir ** "*.avdl").get) {
+    for (idl <- (srcDir ** "*.avdl").get if inFilter.accept(idl) && !exFilter.accept(idl)) {
       log.info("Compiling Avro IDL %s".format(idl))
       generator.fileToFile(idl, target.getPath)
     }
 
-
-    for (inFile <- (srcDir ** "*.avro").get) {
+    for (inFile <- (srcDir ** "*.avro").get if inFilter.accept(inFile) && !exFilter.accept(inFile)) {
       log.info("Compiling Avro datafile %s".format(inFile))
       generator.fileToFile(inFile, target.getPath)
     }
 
-    for (protocol <- (srcDir ** "*.avpr").get) {
+    for (protocol <- (srcDir ** "*.avpr").get if inFilter.accept(protocol) && !exFilter.accept(protocol)) {
       log.info("Compiling Avro protocol %s".format(protocol))
       generator.fileToFile(protocol, target.getPath)
     }

--- a/src/main/scala/sbtavrohugger/formats/scavro/ScavroAvroSettings.scala
+++ b/src/main/scala/sbtavrohugger/formats/scavro/ScavroAvroSettings.scala
@@ -3,23 +3,11 @@ package formats
 package scavro
 
 import ScavroGeneratorTask.scavroCaseClassGeneratorTask
-import AvrohuggerSettings.{
-  avroScalaCustomTypes,
-  avroScalaCustomNamespace,
-  avroScalaCustomEnumStyle
-}
-
+import AvrohuggerSettings.{avroScalaCustomEnumStyle, avroScalaCustomNamespace, avroScalaCustomTypes}
 import java.io.File
 
 import sbt.Keys._
-import sbt.{
-  Compile,
-  Configuration,
-  Setting,
-  Task,
-  TaskKey,
-  inConfig
-}
+import sbt.{AllPassFilter, Compile, Configuration, NothingFilter, Setting, Task, TaskKey, inConfig}
 
 object ScavroSettings {
 
@@ -44,7 +32,9 @@ object ScavroSettings {
           sourceGenerators in Compile <+= (generateScavro in avroConfig),
           managedSourceDirectories in Compile <+= (scalaSource in avroConfig),
           cleanFiles <+= (scalaSource in avroConfig),
-          ivyConfigurations += avroConfig)
+          ivyConfigurations += avroConfig,
+          includeFilter := AllPassFilter,
+          excludeFilter := NothingFilter)
   }
 
 }

--- a/src/main/scala/sbtavrohugger/formats/scavro/ScavroGeneratorTask.scala
+++ b/src/main/scala/sbtavrohugger/formats/scavro/ScavroGeneratorTask.scala
@@ -4,24 +4,11 @@ package scavro
 
 import avrohugger.Generator
 import avrohugger.format.Scavro
-
-import AvrohuggerSettings.{
-  avroScalaCustomTypes,
-  avroScalaCustomNamespace,
-  avroScalaCustomEnumStyle
-}
-
+import AvrohuggerSettings.{avroScalaCustomEnumStyle, avroScalaCustomNamespace, avroScalaCustomTypes}
 import java.io.File
 
 import sbt.Keys._
-import sbt.{
-  FileFunction,
-  FilesInfo,
-  Logger,
-  globFilter,
-  richFile,
-  singleFileFinder
-}
+import sbt.{FileFunction, FilesInfo, Logger, globFilter, richFile, singleFileFinder}
 
 object ScavroGeneratorTask {
 
@@ -32,13 +19,15 @@ object ScavroGeneratorTask {
     avroScalaCustomTypes in avroConfig,
     avroScalaCustomNamespace in avroConfig,
     avroScalaCustomEnumStyle in avroConfig,
-    target) map {
-      (out, srcDir, targetDir, customTypes, customNamespace, customEnumStyle, cache) =>
+    target,
+    includeFilter in avroConfig,
+    excludeFilter in avroConfig) map {
+      (out, srcDir, targetDir, customTypes, customNamespace, customEnumStyle, cache, inFilter, exFilter) =>
         val cachedCompile = FileFunction.cached(cache / "avro",
           inStyle = FilesInfo.lastModified,
           outStyle = FilesInfo.exists) { (in: Set[File]) =>
             val generator = new Generator(Scavro, customTypes, customNamespace, customEnumStyle)
-            FileWriter.generateCaseClasses(generator, srcDir, targetDir, out.log)
+            FileWriter.generateCaseClasses(generator, srcDir, targetDir, out.log, inFilter, exFilter)
           }
         cachedCompile((srcDir ** "*.av*").get.toSet).toSeq
     }

--- a/src/main/scala/sbtavrohugger/formats/specific/SpecificAvroSettings.scala
+++ b/src/main/scala/sbtavrohugger/formats/specific/SpecificAvroSettings.scala
@@ -3,23 +3,11 @@ package formats
 package specific
 
 import SpecificGeneratorTask.specificCaseClassGeneratorTask
-import AvrohuggerSettings.{
-  avroScalaCustomTypes,
-  avroScalaCustomNamespace,
-  avroScalaCustomEnumStyle
-}
-
+import AvrohuggerSettings.{avroScalaCustomEnumStyle, avroScalaCustomNamespace, avroScalaCustomTypes}
 import java.io.File
 
 import sbt.Keys._
-import sbt.{
-  Compile,
-  Configuration,
-  Setting,
-  Task,
-  TaskKey,
-  inConfig
-}
+import sbt.{AllPassFilter, Compile, Configuration, NothingFilter, Setting, Task, TaskKey, inConfig}
 
 object SpecificAvroSettings {
 

--- a/src/main/scala/sbtavrohugger/formats/specific/SpecificAvroSettings.scala
+++ b/src/main/scala/sbtavrohugger/formats/specific/SpecificAvroSettings.scala
@@ -44,7 +44,9 @@ object SpecificAvroSettings {
           sourceGenerators in Compile <+= (generateSpecific in avroConfig),
           managedSourceDirectories in Compile <+= (scalaSource in avroConfig),
           cleanFiles <+= (scalaSource in avroConfig),
-          ivyConfigurations += avroConfig)
+          ivyConfigurations += avroConfig,
+          includeFilter := AllPassFilter,
+          excludeFilter := NothingFilter)
   }
 
 }

--- a/src/main/scala/sbtavrohugger/formats/specific/SpecificGeneratorTask.scala
+++ b/src/main/scala/sbtavrohugger/formats/specific/SpecificGeneratorTask.scala
@@ -32,13 +32,15 @@ object SpecificGeneratorTask {
     avroScalaCustomTypes in avroConfig,
     avroScalaCustomNamespace in avroConfig,
     avroScalaCustomEnumStyle in avroConfig,
-    target) map {
-      (out, srcDir, targetDir, customTypes, customNamespace, customEnumStyle, cache) =>
+    target,
+    includeFilter in avroConfig,
+    excludeFilter in avroConfig) map {
+      (out, srcDir, targetDir, customTypes, customNamespace, customEnumStyle, cache, inFilter, exFilter) =>
         val cachedCompile = FileFunction.cached(cache / "avro",
           inStyle = FilesInfo.lastModified,
           outStyle = FilesInfo.exists) { (in: Set[File]) =>
             val generator = new Generator(SpecificRecord, customTypes, customNamespace, customEnumStyle)
-            FileWriter.generateCaseClasses(generator, srcDir, targetDir, out.log)
+            FileWriter.generateCaseClasses(generator, srcDir, targetDir, out.log, inFilter, exFilter)
           }
         cachedCompile((srcDir ** "*.av*").get.toSet).toSeq
     }

--- a/src/main/scala/sbtavrohugger/formats/standard/AvroSettings.scala
+++ b/src/main/scala/sbtavrohugger/formats/standard/AvroSettings.scala
@@ -43,7 +43,9 @@ object AvroSettings  {
       sourceGenerators in Compile <+= (generate in avroConfig),
       managedSourceDirectories in Compile <+= (scalaSource in avroConfig),
       cleanFiles <+= (scalaSource in avroConfig),
-      ivyConfigurations += avroConfig)
+      ivyConfigurations += avroConfig,
+      includeFilter := AllPassFilter,
+      excludeFilter := NothingFilter)
   }
 
 }

--- a/src/main/scala/sbtavrohugger/formats/standard/AvroSettings.scala
+++ b/src/main/scala/sbtavrohugger/formats/standard/AvroSettings.scala
@@ -3,23 +3,11 @@ package formats
 package standard
 
 import GeneratorTask.caseClassGeneratorTask
-import AvrohuggerSettings.{
-  avroScalaCustomTypes,
-  avroScalaCustomNamespace,
-  avroScalaCustomEnumStyle
-}
-
+import AvrohuggerSettings.{avroScalaCustomEnumStyle, avroScalaCustomNamespace, avroScalaCustomTypes}
 import java.io.File
 
 import sbt.Keys._
-import sbt.{
-  Compile,
-  Configuration,
-  Setting,
-  Task,
-  TaskKey,
-  inConfig
-}
+import sbt.{AllPassFilter, Compile, Configuration, NothingFilter, Setting, Task, TaskKey, inConfig}
 
 object AvroSettings  {
 

--- a/src/main/scala/sbtavrohugger/formats/standard/GeneratorTask.scala
+++ b/src/main/scala/sbtavrohugger/formats/standard/GeneratorTask.scala
@@ -32,13 +32,15 @@ object GeneratorTask {
     avroScalaCustomTypes in avroConfig,
     avroScalaCustomNamespace in avroConfig,
     avroScalaCustomEnumStyle in avroConfig,
-    target) map {
-      (out, srcDir, targetDir, customTypes, customNamespace, customEnumStyle, cache) =>
+    target,
+    includeFilter in avroConfig,
+    excludeFilter in avroConfig) map {
+      (out, srcDir, targetDir, customTypes, customNamespace, customEnumStyle, cache, inFilter, exFilter) =>
         val cachedCompile = FileFunction.cached(cache / "avro",
           inStyle = FilesInfo.lastModified,
           outStyle = FilesInfo.exists) { (in: Set[File]) =>
             val gen = new Generator(Standard, customTypes, customNamespace, customEnumStyle)
-            FileWriter.generateCaseClasses(gen, srcDir, targetDir, out.log)
+            FileWriter.generateCaseClasses(gen, srcDir, targetDir, out.log, inFilter, exFilter)
           }
         cachedCompile((srcDir ** "*.av*").get.toSet).toSeq
     }


### PR DESCRIPTION
I came across a case where I had a couple of Avro schemas that I don't want to generate classes for, so I added the ability to exclude / include specific files. Per default all goes through.

By the way, did you remove sbt-scripted?
