### PR TITLE
Map support in reffered type finder

### DIFF
--- a/src/main/scala/sbtavrohugger/filesorter/ReferredTypeFinder.scala
+++ b/src/main/scala/sbtavrohugger/filesorter/ReferredTypeFinder.scala
@@ -9,12 +9,14 @@ import spray.json._
   * by Jerome Wascongne
   */
 object ReferredTypeFinder {
-  
+
   object Keys {
     val Fields = "fields"
     val Type = "type"
     val Items = "items"
+    val Values = "values"
     val Array = "array"
+    val Map = "map"
     val Enum = "enum"
     val Record = "record"
     val Name = "name"
@@ -26,6 +28,7 @@ object ReferredTypeFinder {
       val typeOfRef = fields(Keys.Type)
       typeOfRef match {
         case JsString(Keys.Array) => findReferredTypes(fields(Keys.Items))
+        case JsString(Keys.Map) => findReferredTypes(fields(Keys.Values))
         case JsString(Keys.Enum) => List(fields(Keys.Name).convertTo[String])
         case JsString(Keys.Record) => findReferredTypes(fields(Keys.Fields))
         case nestedDefinition => findReferredTypes(nestedDefinition)

--- a/src/test/resources/dependencies/A.avsc
+++ b/src/test/resources/dependencies/A.avsc
@@ -1,0 +1,11 @@
+{
+  "name" : "A",
+  "type" : "record",
+  "namespace" : "common",
+  "fields" : [
+    {
+      "name": "any",
+      "type": "int"
+    }
+  ]
+}

--- a/src/test/resources/dependencies/MapRef.avsc
+++ b/src/test/resources/dependencies/MapRef.avsc
@@ -1,0 +1,14 @@
+{
+  "name": "MapRef",
+  "type": "record",
+  "namespace": "common",
+  "fields": [
+    {
+      "name": "a",
+      "type": {
+        "type": "map",
+        "values": "common.A"
+      }
+    }
+  ]
+}

--- a/src/test/scala/sbtavrohugger/SbtAvroDependenciesSpec.scala
+++ b/src/test/scala/sbtavrohugger/SbtAvroDependenciesSpec.scala
@@ -13,9 +13,12 @@ class SbtAvroDependenciesSpec extends Specification {
   val simpleArrayRef = new File(sourceDir, "SimpleArrayRef.avsc")
   val enumRef = new File(sourceDir, "EnumRef.avsc")
   val zFile = new File(sourceDir, "Z.avsc")
+  val aFile = new File(sourceDir, "A.avsc")
+  val mapRef = new File(sourceDir, "MapRef.avsc")
   val unionRef = new File(sourceDir, "UnionRef.avsc")
   val sourceFiles = Seq(arrayRef, zFile, unionRef)
   val sourceFiles2 = Seq(simpleArrayRef, zFile, unionRef)
+  val sourceFiles3 = Seq(mapRef, aFile)
   val sourceFilesWithEnum = Seq(enumRef)
 
   "Schema files should be sorted correctly for union and array references" >> {
@@ -30,5 +33,10 @@ class SbtAvroDependenciesSpec extends Specification {
 
   "Schema files should be sorted correctly for enum references" >> {
     AVSCFileSorter.sortSchemaFiles(sourceFilesWithEnum) must beEqualTo(Seq(enumRef))
+  }
+
+  "Schema files should be sorted correctly for map references" >> {
+    AVSCFileSorter.sortSchemaFiles(sourceFiles3) must beEqualTo(Seq(aFile, mapRef))
+    AVSCFileSorter.sortSchemaFiles(sourceFiles3.reverse) must beEqualTo(Seq(aFile, mapRef))
   }
 }


### PR DESCRIPTION
Added support for "map" type in ReferredTypeFinder

This fixes file ordering bug if referred type is declared as
`"type": {"type": "map", "values" : "referredType" }`