### PR TITLE
Added serialization tests for `decimal` backed by `scala.math.BigDecimal`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ crossSbtVersions := Seq("0.13.16", sbtVersion.value)
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard")
 
 libraryDependencies ++= Seq(
-  "com.julianpeeters" %% "avrohugger-core" % "1.0.0-RC8",
-  "com.julianpeeters" %% "avrohugger-filesorter" % "1.0.0-RC8",
+  "com.julianpeeters" %% "avrohugger-core" % "1.0.0-RC9-SNAPSHOT",
+  "com.julianpeeters" %% "avrohugger-filesorter" % "1.0.0-RC9-SNAPSHOT",
   "io.spray" %% "spray-json" % "1.3.2",
   "org.specs2" %% "specs2-core" % "3.8.6" % "test")
 

--- a/src/sbt-test/avrohugger/GenericSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/build.sbt
@@ -10,9 +10,9 @@ crossScalaVersions := Seq("2.11.8", "2.12.4")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard")
 
-libraryDependencies += "com.sksamuel.avro4s" %% "avro4s-core" % "1.8.0"
+libraryDependencies += "com.sksamuel.avro4s" %% "avro4s-core" % "1.8.3"
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.8.2"
 
 libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.3"
 

--- a/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/decimal.avdl
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/decimal.avdl
@@ -1,0 +1,9 @@
+@namespace("test")
+
+protocol DecimalIDL {
+
+  record DecimalIdl {
+    decimal(9, 2) dec = 8888.88;
+  }
+
+}

--- a/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/decimal.avdl
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/decimal.avdl
@@ -6,4 +6,8 @@ protocol DecimalIDL {
     decimal(9, 2) dec = 8888.88;
   }
 
+  record UnionWithRecordOverBigDecimal {
+    union { DecimalIdl, null } maybeDecimalIdl = null;
+  }
+
 }

--- a/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/decimal.avsc
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/src/main/avro/decimal.avsc
@@ -1,0 +1,16 @@
+{
+  "namespace": "test",
+  "type": "record",
+  "name": "DecimalSc",
+  "fields": [
+    {
+      "name": "dec",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 9,
+        "scale": 2
+      }
+    }
+  ]
+}

--- a/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
@@ -65,7 +65,7 @@ class StandardPrimitivesSpec extends Specification {
     }
   }
 
-  "A case class with a `BigDecimal` field" should {
+  "A case class with a `BigDecimal` field from .avdl" should {
     "deserialize correctly" in {
       val record1 = DecimalIdl(BigDecimal(10.0))
       val record2 = DecimalIdl(BigDecimal(10.0))
@@ -75,9 +75,8 @@ class StandardPrimitivesSpec extends Specification {
     }
   }
 
-  "A case class with a `BigDecimal` field and default values" should {
+  "A case class with a `BigDecimal` field and default values from .avdl" should {
     "deserialize correctly" in {
-      val bs: ToSchema[scala.math.BigDecimal] = implicitly[ToSchema[scala.math.BigDecimal]]
       val record1 = DecimalIdl()
       val record2 = DecimalIdl()
       val format = RecordFormat[DecimalIdl]
@@ -85,6 +84,17 @@ class StandardPrimitivesSpec extends Specification {
       StandardTestUtil.verifyWriteAndRead(records)
     }
   }
+
+  "A case class with a `BigDecimal` field from .avsc" should {
+    "deserialize correctly" in {
+      val record1 = DecimalSc(BigDecimal(10.0))
+      val record2 = DecimalSc(BigDecimal(10.0))
+      val format = RecordFormat[DecimalSc]
+      val records = List(format.to(record1), format.to(record2))
+      StandardTestUtil.verifyWriteAndRead(records)
+    }
+  }
+
 /*
   Avro4s is used to convert to `GenericRecord` for testing, chokes on `null`
   "A case class with an `Null` field" should {

--- a/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
@@ -95,7 +95,7 @@ class StandardPrimitivesSpec extends Specification {
     }
   }
 
-  "A case class with a union / optional BigDecimal contained withing a Record from .avdl" should {
+  "A case class with a union / optional BigDecimal contained within a Record from .avdl" should {
     "deserialize correctly" in {
       val record1 = UnionWithRecordOverBigDecimal(Some(DecimalIdl(BigDecimal(10.0))))
       val record2 = UnionWithRecordOverBigDecimal(Some(DecimalIdl(BigDecimal(10.0))))

--- a/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
@@ -1,6 +1,7 @@
 import test._
 import org.specs2.mutable.Specification
-import com.sksamuel.avro4s.RecordFormat
+import com.sksamuel.avro4s._
+import com.sksamuel.avro4s.ToSchema._
 
 class StandardPrimitivesSpec extends Specification {
 
@@ -59,6 +60,27 @@ class StandardPrimitivesSpec extends Specification {
       val record1 = AvroTypeProviderTest05("hello world")
       val record2 = AvroTypeProviderTest05("hello galaxy")
       val format = RecordFormat[AvroTypeProviderTest05]
+      val records = List(format.to(record1), format.to(record2))
+      StandardTestUtil.verifyWriteAndRead(records)
+    }
+  }
+
+  "A case class with a `BigDecimal` field" should {
+    "deserialize correctly" in {
+      val record1 = DecimalIdl(10.0)
+      val record2 = DecimalIdl(10.0)
+      val format = RecordFormat[DecimalIdl]
+      val records = List(format.to(record1), format.to(record2))
+      StandardTestUtil.verifyWriteAndRead(records)
+    }
+  }
+
+  "A case class with a `BigDecimal` field and default values" should {
+    "deserialize correctly" in {
+      val bs: ToSchema[scala.math.BigDecimal] = implicitly[ToSchema[scala.math.BigDecimal]]
+      val record1 = DecimalIdl()
+      val record2 = DecimalIdl()
+      val format = RecordFormat[DecimalIdl]
       val records = List(format.to(record1), format.to(record2))
       StandardTestUtil.verifyWriteAndRead(records)
     }

--- a/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
@@ -67,8 +67,8 @@ class StandardPrimitivesSpec extends Specification {
 
   "A case class with a `BigDecimal` field" should {
     "deserialize correctly" in {
-      val record1 = DecimalIdl(10.0)
-      val record2 = DecimalIdl(10.0)
+      val record1 = DecimalIdl(BigDecimal(10.0))
+      val record2 = DecimalIdl(BigDecimal(10.0))
       val format = RecordFormat[DecimalIdl]
       val records = List(format.to(record1), format.to(record2))
       StandardTestUtil.verifyWriteAndRead(records)

--- a/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/src/test/scala/test/standard/StandardPrimitivesSpec.scala
@@ -95,6 +95,18 @@ class StandardPrimitivesSpec extends Specification {
     }
   }
 
+  "A case class with a union / optional BigDecimal contained withing a Record from .avdl" should {
+    "deserialize correctly" in {
+      val record1 = UnionWithRecordOverBigDecimal(Some(DecimalIdl(BigDecimal(10.0))))
+      val record2 = UnionWithRecordOverBigDecimal(Some(DecimalIdl(BigDecimal(10.0))))
+      val format = RecordFormat[UnionWithRecordOverBigDecimal]
+      val records = List(format.to(record1), format.to(record2))
+      StandardTestUtil.verifyWriteAndRead(records)
+    }
+  }
+
+
+
 /*
   Avro4s is used to convert to `GenericRecord` for testing, chokes on `null`
   "A case class with an `Null` field" should {


### PR DESCRIPTION
sbt-avrohugger serialization tests for https://github.com/julianpeeters/avrohugger/pull/86