### PR TITLE
Add the tests for the logical types in specific records.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-avrohugger"
 organization := "com.julianpeeters"
 description := "Sbt plugin for compiling Avro to Scala"
 
-version := "2.0.0-RC10"
+version := "2.0.0-RC11-SNAPSHOT"
 
 sbtPlugin := true
 
@@ -11,8 +11,8 @@ crossSbtVersions := Seq("0.13.16", sbtVersion.value)
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard")
 
 libraryDependencies ++= Seq(
-  "com.julianpeeters" %% "avrohugger-core" % "1.0.0-RC10",
-  "com.julianpeeters" %% "avrohugger-filesorter" % "1.0.0-RC10",
+  "com.julianpeeters" %% "avrohugger-core" % "1.0.0-RC11-SNAPSHOT",
+  "com.julianpeeters" %% "avrohugger-filesorter" % "1.0.0-RC11-SNAPSHOT",
   "io.spray" %% "spray-json" % "1.3.2",
   "org.specs2" %% "specs2-core" % "3.8.6" % "test")
 

--- a/src/sbt-test/avrohugger/SpecificSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/SpecificSerializationTests/build.sbt
@@ -10,8 +10,10 @@ crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.4")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard")
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "com.julianpeeters" %% "avrohugger-core" % "1.0.0-RC11-SNAPSHOT"
 
-libraryDependencies += "org.apache.avro" % "avro-ipc" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.8.2"
+
+libraryDependencies += "org.apache.avro" % "avro-ipc" % "1.8.2"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.6" % "test"

--- a/src/sbt-test/avrohugger/SpecificSerializationTests/src/main/avro/logical.avdl
+++ b/src/sbt-test/avrohugger/SpecificSerializationTests/src/main/avro/logical.avdl
@@ -1,0 +1,12 @@
+@namespace("test")
+
+protocol LogicalIDL {
+
+  record LogicalIdl {
+    decimal(20, 8) dec = 8888.88;
+//    union {decimal(20, 8), null} maybeDec = null;
+    timestamp_ms ts = 1526573732000; //ms from the unix epoch
+    date dt = 600; //days from the unix epock, no time precission
+  }
+
+}

--- a/src/sbt-test/avrohugger/SpecificSerializationTests/src/main/avro/logical.avsc
+++ b/src/sbt-test/avrohugger/SpecificSerializationTests/src/main/avro/logical.avsc
@@ -1,0 +1,30 @@
+{
+  "namespace": "test",
+  "type": "record",
+  "name": "LogicalSc",
+  "fields": [
+    {
+      "name": "data",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 20,
+        "scale": 8
+      }
+    },
+    {
+      "name": "ts",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      }
+    },
+    {
+      "name": "dt",
+      "type": {
+        "type": "int",
+        "logicalType": "date"
+      }
+    }
+  ]
+}

--- a/src/sbt-test/avrohugger/SpecificSerializationTests/src/test/scala/SpecificTestUtil.scala
+++ b/src/sbt-test/avrohugger/SpecificSerializationTests/src/test/scala/SpecificTestUtil.scala
@@ -17,11 +17,11 @@ import org.specs2.mutable.Specification
 object SpecificTestUtil extends Specification {
 
   def write[T <: SpecificRecordBase](file: File, records: List[T]) = {
-    val userDatumWriter = new SpecificDatumWriter[T]
+    val userDatumWriter = new SpecificDatumWriter[T]()
     val dataFileWriter = new DataFileWriter[T](userDatumWriter)
-    dataFileWriter.create(records.head.getSchema, file);
+    dataFileWriter.create(records.head.getSchema, file)
     records.foreach(record => dataFileWriter.append(record))
-    dataFileWriter.close();
+    dataFileWriter.close()
   }
 
   def read[T <: SpecificRecordBase](file: File, records: List[T]) = {

--- a/src/sbt-test/avrohugger/SpecificSerializationTests/src/test/scala/specific/SpecificPrimitivesSpec.scala
+++ b/src/sbt-test/avrohugger/SpecificSerializationTests/src/test/scala/specific/SpecificPrimitivesSpec.scala
@@ -1,7 +1,14 @@
-import test._
+import java.time._
+
 import org.specs2.mutable.Specification
+import test._
 
 class SpecificPrimitivesSpec extends Specification {
+
+  private val zone: ZoneId = ZoneId.of("UTC")
+  val instant = LocalDateTime.of(2018, 6, 12, 18, 0).atZone(zone).toInstant
+  val clock = Clock.fixed(instant, zone)
+  private val bigDecimal = BigDecimal(10.0).setScale(8)
 
   "A case class with an `Int` field" should {
     "deserialize correctly" in {
@@ -61,6 +68,24 @@ class SpecificPrimitivesSpec extends Specification {
     "deserialize correctly" in {
       val record1 = AvroTypeProviderTest06(null)
       val record2 = AvroTypeProviderTest06(null)
+      val records = List(record1, record2)
+      SpecificTestUtil.verifyWriteAndRead(records)
+    }
+  }
+
+  "A case class with `logicalType` fields and explicit values from .avdl" should {
+    "deserialize correctly" in {
+      val record1 = LogicalIdl(bigDecimal, LocalDateTime.now(clock), LocalDate.now(clock))
+      val record2 = LogicalIdl(bigDecimal, LocalDateTime.now(clock), LocalDate.now(clock))
+      val records = List(record1, record2)
+      SpecificTestUtil.verifyWriteAndRead(records)
+    }
+  }
+
+  "A case class with a `logicalType` fields from .avsc" should {
+    "deserialize correctly" in {
+      val record1 = LogicalSc(bigDecimal, LocalDateTime.now(clock), LocalDate.now(clock))
+      val record2 = LogicalSc(bigDecimal, LocalDateTime.now(clock), LocalDate.now(clock))
       val records = List(record1, record2)
       SpecificTestUtil.verifyWriteAndRead(records)
     }

--- a/src/sbt-test/sbt-avrohugger/specific/build.sbt
+++ b/src/sbt-test/sbt-avrohugger/specific/build.sbt
@@ -4,4 +4,4 @@ sourceGenerators in Compile += (avroScalaGenerateSpecific in Compile).taskValue
 
 scalaVersion := "2.12.4"
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.8.2"


### PR DESCRIPTION
Currently some of the tests do not pass for two reasons:
1. apparently Avro is not able to decode unions with a logical types, unless the value is null
2. the comparison in the test fails with this error: java.lang.ClassCastException: scala.math.BigDecimal cannot be cast to java.lang.Comparable (GenericData.java:998)

I have removed the first cause from the tests for the moment.
I need advice on how to proceed.