### PR TITLE
Update scripted tests to use avrohugger with avro 1.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,8 @@ crossSbtVersions := Seq(sbtVersion.value)
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard")
 
 libraryDependencies ++= Seq(
-  "com.julianpeeters" %% "avrohugger-core" % "1.0.0-RC18-SNAPSHOT",
-  "com.julianpeeters" %% "avrohugger-filesorter" % "1.0.0-RC18-SNAPSHOT",
+  "com.julianpeeters" %% "avrohugger-core" % "1.0.0-RC18",
+  "com.julianpeeters" %% "avrohugger-filesorter" % "1.0.0-RC18",
   "io.spray" %% "spray-json" % "1.3.2",
   "org.specs2" %% "specs2-core" % "3.8.6" % "test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-avrohugger"
 organization := "com.julianpeeters"
 description := "Sbt plugin for compiling Avro to Scala"
 
-version := "2.0.0-RC17"
+version := "2.0.0-RC18-SNAPSHOT"
 
 enablePlugins(SbtPlugin)
 
@@ -17,8 +17,8 @@ crossSbtVersions := Seq(sbtVersion.value)
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard")
 
 libraryDependencies ++= Seq(
-  "com.julianpeeters" %% "avrohugger-core" % "1.0.0-RC17",
-  "com.julianpeeters" %% "avrohugger-filesorter" % "1.0.0-RC17",
+  "com.julianpeeters" %% "avrohugger-core" % "1.0.0-RC18-SNAPSHOT",
+  "com.julianpeeters" %% "avrohugger-filesorter" % "1.0.0-RC18-SNAPSHOT",
   "io.spray" %% "spray-json" % "1.3.2",
   "org.specs2" %% "specs2-core" % "3.8.6" % "test")
 

--- a/src/sbt-test/avrohugger/GenericADTSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/GenericADTSerializationTests/build.sbt
@@ -17,7 +17,7 @@ avroScalaCustomTypes in Compile := {
 
 libraryDependencies += "com.sksamuel.avro4s" %% "avro4s-core" % "1.8.0"
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.3"
 

--- a/src/sbt-test/avrohugger/GenericCaseObjectEnumSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/GenericCaseObjectEnumSerializationTests/build.sbt
@@ -25,6 +25,6 @@ libraryDependencies := {
   }
 }
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.6"

--- a/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/build.sbt
@@ -12,7 +12,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-di
 
 libraryDependencies += "com.sksamuel.avro4s" %% "avro4s-core" % "1.9.0"
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.6"
 

--- a/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/src/main/avro/DecimalsTagged.avdl
+++ b/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/src/main/avro/DecimalsTagged.avdl
@@ -4,22 +4,23 @@ protocol DecimalsTagged {
   record LogicalIdl {
     decimal(8, 2) dec;
     union {decimal(8, 2), null} maybeDec;
-    decimal(8, 2) decWithDefault = 1111.11;
-    union {decimal(8, 2), null} maybeDecWithDefault = 2222.22;
+    decimal(8, 2) decWithDefault = "1111.11";
+    union {decimal(9, 2), string, boolean} maybeDec2 = "9999.99";
+
   }
 
   record LogicalIdlBigPrecision {
     decimal(20, 8) dec;
     union {decimal(20, 8), null} maybeDec;
-    decimal(20, 8) decWithDefault = 1111.11;
-    union {decimal(20, 8), null} maybeDecWithDefault = 2222.22;
+    decimal(20, 8) decWithDefault = "1111.11";
+    union {decimal(9, 2), string, boolean} maybeDec2 = "9999.99";
   }
 
   record LogicalIdlBigPrecisionAndScale {
     decimal(20, 12) dec;
     union {decimal(20, 12), null} maybeDec;
-    decimal(20, 12) decWithDefault = 1111.11;
-    union {decimal(20, 12), null} maybeDecWithDefault = 2222.22;
+    decimal(20, 12) decWithDefault = "1111.11";
+    union {decimal(9, 2), string, boolean} maybeDec2 = "9999.99";
   }
 
 }

--- a/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/src/main/avro/logical_coproduct.avdl
+++ b/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/src/main/avro/logical_coproduct.avdl
@@ -3,7 +3,7 @@
 protocol LogicalCoproductIDL {
 
   record LogicalCoproductIdl {
-    union {decimal(9, 2), string, boolean} maybeDec = 9999.99;
+    union {decimal(9, 2), string, boolean} maybeDec = "9999.99";
   }
 
 }

--- a/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/src/main/avro/logical_either.avdl
+++ b/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/src/main/avro/logical_either.avdl
@@ -3,7 +3,7 @@
 protocol LogicalEitherIDL {
 
   record LogicalEitherIdl {
-    union {decimal(9, 2), string} maybeDec = 9999.99;
+    union {decimal(9, 2), string} maybeDec = "9999.99";
   }
 
 }

--- a/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/src/main/avro/logical_optional.avdl
+++ b/src/sbt-test/avrohugger/GenericDecimalTaggedSerializationTests/src/main/avro/logical_optional.avdl
@@ -3,7 +3,7 @@
 protocol LogicalOptionalIDL {
 
   record LogicalOptionalIdl {
-    union {decimal(9, 2), null} maybeDec = 9999.99;
+    union {decimal(9, 2), null} maybeDec = "9999.99";
   }
 
 }

--- a/src/sbt-test/avrohugger/GenericJavaEnumSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/GenericJavaEnumSerializationTests/build.sbt
@@ -24,6 +24,6 @@ libraryDependencies := {
   }
 }
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.6"

--- a/src/sbt-test/avrohugger/GenericOptionShapelessUnionsSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/GenericOptionShapelessUnionsSerializationTests/build.sbt
@@ -12,7 +12,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-di
 
 libraryDependencies += "com.sksamuel.avro4s" %% "avro4s-core" % "1.8.0"
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.6"
 

--- a/src/sbt-test/avrohugger/GenericOptionalShapelessUnionsSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/GenericOptionalShapelessUnionsSerializationTests/build.sbt
@@ -12,7 +12,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-di
 
 libraryDependencies += "com.sksamuel.avro4s" %% "avro4s-core" % "1.8.0"
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.6"
 

--- a/src/sbt-test/avrohugger/GenericSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/GenericSerializationTests/build.sbt
@@ -12,7 +12,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-di
 
 libraryDependencies += "com.sksamuel.avro4s" %% "avro4s-core" % "1.9.0"
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.8.2"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.3"
 

--- a/src/sbt-test/avrohugger/GenericStringEnumSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/GenericStringEnumSerializationTests/build.sbt
@@ -24,6 +24,6 @@ libraryDependencies := {
   }
 }
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.6"

--- a/src/sbt-test/avrohugger/OverrideSettings/build.sbt
+++ b/src/sbt-test/avrohugger/OverrideSettings/build.sbt
@@ -12,5 +12,5 @@ version := "0.1-SNAPSHOT"
 
 crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.4")
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 

--- a/src/sbt-test/avrohugger/SpecificADTSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/SpecificADTSerializationTests/build.sbt
@@ -15,7 +15,7 @@ avroScalaCustomTypes in Compile := {
     protocol = avrohugger.types.ScalaADT)
 }
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "org.apache.avro" % "avro-ipc" % "1.7.7"
 

--- a/src/sbt-test/avrohugger/SpecificSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/SpecificSerializationTests/build.sbt
@@ -10,8 +10,8 @@ crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.4")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard")
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.8.2"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
-libraryDependencies += "org.apache.avro" % "avro-ipc" % "1.8.2"
+libraryDependencies += "org.apache.avro" % "avro-ipc-netty" % "1.9.0"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "3.8.6"

--- a/src/sbt-test/avrohugger/SpecificSerializationTests/src/main/avro/logical.avdl
+++ b/src/sbt-test/avrohugger/SpecificSerializationTests/src/main/avro/logical.avdl
@@ -3,7 +3,7 @@
 protocol LogicalIDL {
 
   record LogicalIdl {
-    decimal(20, 8) dec = 8888.88;
+    decimal(20, 8) dec = "8888.88";
     union {null, decimal(20, 8)} maybeDec = null;
     timestamp_ms ts = 1526573732000; //ms from the unix epoch
     date dt = 600; //days from the unix epock, no time precission

--- a/src/sbt-test/avrohugger/SpecificSerializationTests/src/test/scala/specific/SpecificRPCTest.scala
+++ b/src/sbt-test/avrohugger/SpecificSerializationTests/src/test/scala/specific/SpecificRPCTest.scala
@@ -7,8 +7,8 @@ import java.net.InetSocketAddress
 import java.lang.reflect.Proxy
 
 import org.apache.avro.specific.SpecificData
-import org.apache.avro.ipc.NettyServer
-import org.apache.avro.ipc.NettyTransceiver
+import org.apache.avro.ipc.netty.NettyServer
+import org.apache.avro.ipc.netty.NettyTransceiver
 import org.apache.avro.ipc.Server
 import org.apache.avro.ipc.specific.SpecificRequestor
 import org.apache.avro.ipc.specific.SpecificResponder

--- a/src/sbt-test/avrohugger/SpecificStringEnumSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/SpecificStringEnumSerializationTests/build.sbt
@@ -16,7 +16,7 @@ avroScalaSpecificCustomTypes in Compile := {
     array = avrohugger.types.ScalaArray)
 }
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.7.7"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "org.apache.avro" % "avro-ipc" % "1.7.7"
 

--- a/src/sbt-test/avrohugger/SpecificVectorSerializationTests/build.sbt
+++ b/src/sbt-test/avrohugger/SpecificVectorSerializationTests/build.sbt
@@ -16,7 +16,7 @@ crossScalaVersions := Seq("2.10.6", "2.11.11", "2.12.4")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard")
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.8.2"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"
 
 libraryDependencies += "org.apache.avro" % "avro-ipc" % "1.8.2"
 

--- a/src/sbt-test/sbt-avrohugger/module/build.sbt
+++ b/src/sbt-test/sbt-avrohugger/module/build.sbt
@@ -17,7 +17,7 @@ lazy val `submodule` = (project in file("submodule"))
   
 lazy val commonSettings = Seq(
   scalaVersion := "2.12.8",
-  libraryDependencies += "org.apache.avro" % "avro" % "1.8.2",
+  libraryDependencies += "org.apache.avro" % "avro" % "1.9.0",
   libraryDependencies += "org.specs2" %% "specs2-core" % "4.6.0" % Test,
   libraryDependencies += "org.specs2" %% "specs2-scalacheck" % "4.6.0" % Test
 )

--- a/src/sbt-test/sbt-avrohugger/specific/build.sbt
+++ b/src/sbt-test/sbt-avrohugger/specific/build.sbt
@@ -4,4 +4,4 @@ sourceGenerators in Compile += (avroScalaGenerateSpecific in Compile).taskValue
 
 scalaVersion := "2.12.4"
 
-libraryDependencies += "org.apache.avro" % "avro" % "1.8.2"
+libraryDependencies += "org.apache.avro" % "avro" % "1.9.0"


### PR DESCRIPTION
Test fails on logical decimal default values when the decimal is within a 2-member union with null